### PR TITLE
Move to local docker registry

### DIFF
--- a/mlrun-data-flywheel-tutorial.ipynb
+++ b/mlrun-data-flywheel-tutorial.ipynb
@@ -27,40 +27,38 @@
     "MLRun Project is a container for all your work on a particular ML application.\n",
     "Projects host functions, workflows, artifacts (datasets, models, etc.), features (sets, vectors), and configuration (parameters, secrets, source, etc.).\n",
     "\n",
-    "For this project please set up the following variables:\n",
-    "- `NGC_API_KEY` - Following the instructions at [Generating NGC API Keys](https://docs.nvidia.com/ngc/gpu-cloud/ngc-private-registry-user-guide/index.html#generating-api-key)\n",
-    "- `docker_registry` - The Project image (docker image for the workflow's functions) that it will use. Notice that this image was prepared in the previous notebook and all the docker registry credentials are set."
+    "Like in the previous notebook, we need to set the NGC API Key as well:\n",
+    "- `NGC_API_KEY` - Following the instructions at [Generating NGC API Keys](https://docs.nvidia.com/ngc/gpu-cloud/ngc-private-registry-user-guide/index.html#generating-api-key)"
    ]
   },
   {
-   "cell_type": "code",
-   "id": "41a300ed-7454-4090-92b6-097f3683f50d",
    "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "import mlrun\n",
     "import os\n",
+    "from getpass import getpass\n",
     "\n",
-    "os.environ['NGC_API_KEY'] = '<your_ngc_api_key>'\n",
-    "docker_registry = '<your_docker_registry_name>'"
+    "os.environ['NGC_API_KEY'] = getpass(\"Enter your NGC API Key\")"
    ],
-   "outputs": [],
-   "execution_count": null
+   "id": "b75500bdf6900dc9"
   },
   {
-   "cell_type": "code",
-   "id": "ff85f1ea-4060-4cd2-8753-243c15668f99",
    "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "project = mlrun.get_or_create_project(\n",
-    "    name=\"flywheel\",\n",
+    "    name=\"data-flywheel\",\n",
     "    parameters={\n",
-    "        \"image\": f\"{docker_registry}/mlrun-data-flywheel:latest\",\n",
     "        \"source\": \"git://github.com/mlrun/nvidia-data-flywheel.git\",\n",
     "    },    \n",
     ")"
    ],
-   "outputs": [],
-   "execution_count": null
+   "id": "95727de9e89a87bc"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/data-flywheel-bp-tutorial.ipynb
+++ b/notebooks/data-flywheel-bp-tutorial.ipynb
@@ -33,7 +33,13 @@
   },
   {
    "cell_type": "markdown",
-   "source": "### Contents \n\n0. [Data Flywheel Setup](#0)\n1. [Load Sample Data](#1)\n2. [Create a Flywheel Job](#2)\n3. [Monitor Job Status](#3)\n4. [Optional: Show Continuous Improvement](#4)",
+   "source": [
+    "### Contents \n",
+    "\n",
+    "0. [Data Flywheel Setup](#0)\n",
+    "1. [Load Sample Data](#1)\n",
+    "2. [Create a Flywheel Job](#2)"
+   ],
    "metadata": {}
   },
   {
@@ -55,24 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "source": "**Step 2**: Set your docker registry credentials to allow MLRun CE installation. For more information see [MLRun CE Installation](https://docs.mlrun.org/en/latest/install/kubernetes.html#installing-the-chart).",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "os.environ['DOCKER_SERVER'] = '<your_docker_server>'\n",
-    "os.environ['DOCKER_USERNAME'] = '<your_docker_username>'\n",
-    "os.environ['DOCKER_PASSWORD'] = '<your_docker_password>'\n",
-    "os.environ['DOCKER_REGISTRY_URL'] = '<your_docker_registry_url>'"
-   ],
-   "metadata": {},
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "source": "**Step 3**: Clone the data flywheel repo and fetch data files.",
+   "source": "**Step 2**: Clone the data flywheel repo and fetch data files.",
    "metadata": {}
   },
   {
@@ -84,7 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "source": "**Step 4**: Set up paths and install python dependencies for notebook.",
+   "source": "**Step 3**: Set up paths and install python dependencies for notebook.",
    "metadata": {}
   },
   {
@@ -96,7 +85,11 @@
   },
   {
    "cell_type": "markdown",
-   "source": "**Step 5**: Update `config/config.yaml` to use remote LLM as judge. By default, the Data Flywheel Blueprint deploys `LLama-3.3-70B-instruct` locally for LLM as a judge, which requires 4 GPUs. But for the launchable, we will choose the remote LLM judge and use the `LLama-3.3-70B-instruct` NIM hosted on [build.nvidia.com](https://build.nvidia.com/meta/llama-3_3-70b-instruct).\n\nBy default, only `Llama-3.2-1b-instruct` will be used in the flywheel but you can uncomment other models in the yaml file to include in the flywheel run. You can also change other config settings such as data split and training hyperparameters as desired.",
+   "source": [
+    "**Step 4**: Update `config/config.yaml` to use remote LLM as judge. By default, the Data Flywheel Blueprint deploys `LLama-3.3-70B-instruct` locally for LLM as a judge, which requires 4 GPUs. But for the launchable, we will choose the remote LLM judge and use the `LLama-3.3-70B-instruct` NIM hosted on [build.nvidia.com](https://build.nvidia.com/meta/llama-3_3-70b-instruct).\n",
+    "\n",
+    "By default, only `Llama-3.2-1b-instruct` will be used in the flywheel but you can uncomment other models in the yaml file to include in the flywheel run. You can also change other config settings such as data split and training hyperparameters as desired."
+   ],
    "metadata": {}
   },
   {
@@ -108,7 +101,11 @@
   },
   {
    "cell_type": "markdown",
-   "source": "**Step 6**: Start data flywheel service, which involves first deploying the Nemo Microservices and then bring up the data flywheel service via docker compose. This step may take about 15 minutes.\n\n> **Note:** The `deploy-nmp.sh` script automates the deployment of NeMo Microservices. For manual setup or advanced configuration, please consult the [NeMo Microservices documentation](https://docs.nvidia.com/nemo/microservices/latest/get-started/platform-prereq.html#beginner-tutorial-prerequisites).",
+   "source": [
+    "**Step 5**: Start data flywheel service, which involves first deploying the Nemo Microservices and then bring up the data flywheel service via docker compose. This step may take about 15 minutes.\n",
+    "\n",
+    "> **Note:** The `deploy-nmp.sh` script automates the deployment of NeMo Microservices. For manual setup or advanced configuration, please consult the [NeMo Microservices documentation](https://docs.nvidia.com/nemo/microservices/latest/get-started/platform-prereq.html#beginner-tutorial-prerequisites)."
+   ],
    "metadata": {}
   },
   {

--- a/project_setup.py
+++ b/project_setup.py
@@ -15,20 +15,23 @@
 import os
 import mlrun
 
+LOCAL_REGISTRY = "192.168.49.2:5000"
 
 def setup(
         project: mlrun.projects.MlrunProject,
 ) -> mlrun.projects.MlrunProject:
     ngc_api_key = os.getenv("NGC_API_KEY")
     source = project.get_param(key="source")
-    image = project.get_param(key="image")
+    registry = project.get_param(key="registry", default=LOCAL_REGISTRY)
+
+    # This is a workaround for not running the setup if the project is already set up.
+    # It happens when getting the project in the workflow.
     if not source:
         return project
 
     if source:
         project.set_source(source, pull_at_runtime=True)
-    if image:
-        project.set_default_image(image)
+    project.set_default_image(f"{registry}/nvidia-data-flywheel:latest")
     if ngc_api_key:
         project.set_secrets(secrets={'NGC_API_KEY': ngc_api_key})
 

--- a/scripts/deploy-nmp.sh
+++ b/scripts/deploy-nmp.sh
@@ -381,6 +381,7 @@ start_minikube() {
     --cpus=no-limit \
     --memory=no-limit \
     --gpus=all \
+    --insecure-registry="registry.kube-system.svc.cluster.local:5000" \
     $extra_args
 
   log "Enabling ingress addon..."

--- a/scripts/deploy-nmp.sh
+++ b/scripts/deploy-nmp.sh
@@ -375,13 +375,15 @@ start_minikube() {
     log "Running as root, adding --force flag to minikube command"
   fi
 
+  MINIKUBE_IP="192.168.49.2"
   minikube start \
+    --static-ip="$MINIKUBE_IP" \
+    --insecure-registry="$MINIKUBE_IP:5000" \
     --driver=docker \
     --container-runtime=docker \
     --cpus=no-limit \
     --memory=no-limit \
     --gpus=all \
-    --insecure-registry="10.0.0.0/24" \
     $extra_args
 
   log "Enabling ingress addon..."

--- a/scripts/deploy-nmp.sh
+++ b/scripts/deploy-nmp.sh
@@ -381,7 +381,7 @@ start_minikube() {
     --cpus=no-limit \
     --memory=no-limit \
     --gpus=all \
-    --insecure-registry="registry.kube-system.svc.cluster.local:5000" \
+    --insecure-registry="$(minikube ip):5000" \
     $extra_args
 
   log "Enabling ingress addon..."

--- a/scripts/deploy-nmp.sh
+++ b/scripts/deploy-nmp.sh
@@ -381,7 +381,7 @@ start_minikube() {
     --cpus=no-limit \
     --memory=no-limit \
     --gpus=all \
-    --insecure-registry="$(minikube ip):5000" \
+    --insecure-registry="10.0.0.0/24" \
     $extra_args
 
   log "Enabling ingress addon..."

--- a/scripts/mlrun.sh
+++ b/scripts/mlrun.sh
@@ -2,8 +2,10 @@ DOCKER_SERVER="${DOCKER_SERVER:-}"
 DOCKER_USERNAME="${DOCKER_USERNAME:-}"
 DOCKER_PASSWORD="${DOCKER_PASSWORD:-}"
 DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL:-}"
+MLRUN_NAMESPACE="mlrun"
 
-# Remove argo workflows CRDs and patch nemo's workflow controller to use namespaced mode:
+# Remove argo workflows CRDs and patch nemo's workflow controller to use namespaced mode.
+# This is done to avoid running kfp workflows by nemo's workflow controller.
 kubectl get crds | grep 'argoproj.io' | awk '{print $1}' | xargs kubectl delete crd
 kubectl patch deployment nemo-argo-workflows-workflow-controller --type=json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--namespaced"}]'
 
@@ -17,14 +19,35 @@ kubectl create namespace mlrun
 helm repo add mlrun-ce https://mlrun.github.io/ce
 helm repo update
 
+# Set up a local docker registry on the minikube cluster only if docker registry is not provided:
+if [ -z "$DOCKER_REGISTRY_URL" ]; then
+  echo "No docker registry URL provided, setting up a local docker registry on the minikube cluster..."
+  minikube addons enable registry
+#  minikube addons enable registry-creds
+  DOCKER_REGISTRY_URL="http://$(minikube ip):5000"
+  DOCKER_SERVER="$(minikube ip):5000"
+
+  # wait for the registry to be ready:
+  while ! kubectl get pods -n kube-system | grep -q 'registry-'; do
+    echo "Waiting for local docker registry to be ready..."
+    sleep 5
+  done
+fi
+
+# Create a configmap for local docker registry:
+kubectl create configmap registry-config \
+  --namespace=$MLRUN_NAMESPACE \
+  --from-literal=insecure_pull_registry_mode=enabled \
+  --from-literal=insecure_push_registry_mode=enabled
+
 # Create docker registry secrets:
-kubectl --namespace mlrun create secret docker-registry registry-credentials \
+kubectl --namespace $MLRUN_NAMESPACE create secret docker-registry registry-credentials \
     --docker-server $DOCKER_SERVER \
     --docker-username $DOCKER_USERNAME \
     --docker-password=$DOCKER_PASSWORD
 
 # Install mlrun ce:
-helm --namespace mlrun install mlrun-ce --wait --timeout 960s \
+helm --namespace $MLRUN_NAMESPACE install mlrun-ce --wait --timeout 960s \
   --set global.registry.url=$DOCKER_REGISTRY_URL \
   --set global.registry.secretName=registry-credentials \
   --set mlrun.api.image.tag=1.9.0-rc8 \
@@ -42,9 +65,9 @@ docker build -t $DOCKER_REGISTRY_URL/mlrun-data-flywheel:latest -f deploy/mlrun/
 docker push $DOCKER_REGISTRY_URL/mlrun-data-flywheel:latest
 
 # Port forward all essential services and afterwards expose them in the UI:
-kubectl port-forward --namespace mlrun service/mlrun-jupyter 30040:8888 --address=0.0.0.0 &
-kubectl port-forward --namespace mlrun service/nuclio-dashboard 30050:8070 --address=0.0.0.0 &
-kubectl port-forward --namespace mlrun service/mlrun-ui 30060:80 --address=0.0.0.0 &
-kubectl port-forward --namespace mlrun service/minio-console 30090:9001 --address=0.0.0.0 &
-kubectl port-forward --namespace mlrun service/grafana 30010:80 --address=0.0.0.0 &
-kubectl port-forward --namespace mlrun service/monitoring-prometheus 30020:9090 --address=0.0.0.0 &
+kubectl port-forward --namespace $MLRUN_NAMESPACE service/mlrun-jupyter 30040:8888 --address=0.0.0.0 &
+kubectl port-forward --namespace $MLRUN_NAMESPACE service/nuclio-dashboard 30050:8070 --address=0.0.0.0 &
+kubectl port-forward --namespace $MLRUN_NAMESPACE service/mlrun-ui 30060:80 --address=0.0.0.0 &
+kubectl port-forward --namespace $MLRUN_NAMESPACE service/minio-console 30090:9001 --address=0.0.0.0 &
+kubectl port-forward --namespace $MLRUN_NAMESPACE service/grafana 30010:80 --address=0.0.0.0 &
+kubectl port-forward --namespace $MLRUN_NAMESPACE service/monitoring-prometheus 30020:9090 --address=0.0.0.0 &


### PR DESCRIPTION
To support the local Docker registry, the following changes are now applied:
1. Remove content from notebooks regarding the Docker registry in terms of explanations, credentials, etc.
2. Add a default value in the `project_setup.py` for the local Docker registry.
3. In the `scripts/deploy-nmp.sh`, updated the `minikube start` to use a specific IP explicitly and set it as insecure.
4. In the `scripts/mlrun.sh`, we keep the option to use a remote Docker registry, but it's not for the general user, only for development needs.

Extra:
1. Rename the project `flywheel` -> `data-flywheel`
2. Remove the unnecessary steps in Nvidia's notebook table of contents.
3. Add a `NAMESPACE` variable in our setup script.